### PR TITLE
Bugfix in Tle493d.cpp

### DIFF
--- a/src/Tle493d.cpp
+++ b/src/Tle493d.cpp
@@ -43,11 +43,16 @@ void Tle493d::begin(TwoWire &bus, TypeAddress_e slaveAddress, bool reset, uint8_
 		resetSensor();
 	}
 
-	// get all register data from sensor
-	tle493d::readOut(&mInterface);
-
 	//1-byte protocol -> PR = 1
 	setRegBits(tle493d::PR, oneByteRead);
+	 //disable interrupt
+	setRegBits(tle493d::INT, 1);
+	calcParity(tle493d::FP);
+	tle493d::writeOut(&mInterface, tle493d::MOD1_REGISTER);
+	tle493d::writeOut(&mInterface, tle493d::MOD1_REGISTER);
+
+	// get all register data from sensor
+	tle493d::readOut(&mInterface);
 
 	//correct reset values for other product types
 	switch (mProductType)
@@ -137,28 +142,28 @@ bool Tle493d::setAccessMode(AccessMode_e mode)
 
 void Tle493d::enableInterrupt(void)
 {
-	setRegBits(tle493d::INT, 1);
+	setRegBits(tle493d::INT, 0);
 	calcParity(tle493d::FP);
 	tle493d::writeOut(&mInterface, tle493d::MOD1_REGISTER);
 }
 
 void Tle493d::disableInterrupt(void)
 {
-	setRegBits(tle493d::INT, 0);
+	setRegBits(tle493d::INT, 1);
 	calcParity(tle493d::FP);
 	tle493d::writeOut(&mInterface, tle493d::MOD1_REGISTER);
 }
 
 void Tle493d::enableCollisionAvoidance(void)
 {
-	setRegBits(tle493d::CA, 1);
+	setRegBits(tle493d::CA, 0);
 	calcParity(tle493d::FP);
 	tle493d::writeOut(&mInterface, tle493d::MOD1_REGISTER);
 }
 
 void Tle493d::disableCollisionAvoidance(void)
 {
-	setRegBits(tle493d::CA, 0);
+	setRegBits(tle493d::CA, 1);
 	calcParity(tle493d::FP);
 	tle493d::writeOut(&mInterface, tle493d::MOD1_REGISTER);
 }


### PR DESCRIPTION
The problem is, that the first readout function, which should read all sensor registers, just reads 0xFF, because the sensor is not in one-byte-read mode yet.
The solution: 
- Switching to one-byte-read BEFORE first readout -> otherwise readOut() function just reads 0xFF for each register
- Switching off INT BEFORE first readout -> INT may mess up I²C communication
- Writing register MOD1 two times BEFORE first readout -> don't know why this is necessary, but otherwise it doesn't work always. Maybe INT pulse has already occured and 
    destroyed I²C communication, so first writing fails but clears the lines, so that second writing succeeds?

Also: 
 - in functions enable/disableInterrupt(): setting bit to 0 enables interrupt, setting it to 1 disables it (was interchanged here)
 - same for enable/disableCollisionAvoidance()