### PR TITLE
Bugfix for different sensor addresses

### DIFF
--- a/src/Tle493d.cpp
+++ b/src/Tle493d.cpp
@@ -43,13 +43,13 @@ void Tle493d::begin(TwoWire &bus, TypeAddress_e slaveAddress, bool reset, uint8_
 	switch (mProductType)
 	{
 	case TLE493D_A1:
-		setRegBits(tle493d::IICadr, 0x01);
+		setRegBits(tle493d::IICadr, 0b01);
 		break;
 	case TLE493D_A2:
-		setRegBits(tle493d::IICadr, 0x10);
+		setRegBits(tle493d::IICadr, 0b10);
 		break;
 	case TLE493D_A3:
-		setRegBits(tle493d::IICadr, 0x11);
+		setRegBits(tle493d::IICadr, 0b11);
 		break;
 	default:
 		break;

--- a/src/Tle493d.cpp
+++ b/src/Tle493d.cpp
@@ -38,18 +38,7 @@ void Tle493d::begin(TwoWire &bus, TypeAddress_e slaveAddress, bool reset, uint8_
 	{
 		resetSensor();
 	}
-
-	//1-byte protocol -> PR = 1
-	setRegBits(tle493d::PR, oneByteRead);
-	 //disable interrupt
-	setRegBits(tle493d::INT, 1);
-	calcParity(tle493d::FP);
-	tle493d::writeOut(&mInterface, tle493d::MOD1_REGISTER);
-	tle493d::writeOut(&mInterface, tle493d::MOD1_REGISTER);
-
-	// get all register data from sensor
-	tle493d::readOut(&mInterface);
-
+	
 	//correct reset values for other product types
 	switch (mProductType)
 	{
@@ -65,6 +54,17 @@ void Tle493d::begin(TwoWire &bus, TypeAddress_e slaveAddress, bool reset, uint8_
 	default:
 		break;
 	}
+
+	//1-byte protocol -> PR = 1
+	setRegBits(tle493d::PR, oneByteRead);
+	 //disable interrupt
+	setRegBits(tle493d::INT, 1);
+	calcParity(tle493d::FP);
+	tle493d::writeOut(&mInterface, tle493d::MOD1_REGISTER);
+	tle493d::writeOut(&mInterface, tle493d::MOD1_REGISTER);
+
+	// get all register data from sensor
+	tle493d::readOut(&mInterface);
 
 	// default: master controlled mode
 	setAccessMode(mMode);


### PR DESCRIPTION
### Description
**Symptoms**: For other sensor addresses than A0 the library didn't work.
**Problem**: internal reset values are initialized with A0. In the Tle493d::begin() the a tle493d::writeOut() happend (when disabling the interrupt signal and enabling one-byte-read) before the reset values were adapted. Therefore the address-bits in the MOD1-Register were set to 0x00 (configuring address A0).
**Solution**: Correcting the reset values before the first tle493d::writeOut().

### Related Issue
Issue #18 