### PR TITLE
removed IIC bus initialization in begin function

### DIFF
--- a/src/Tle493d.cpp
+++ b/src/Tle493d.cpp
@@ -41,8 +41,6 @@ void Tle493d::begin(TwoWire &bus, TypeAddress_e slaveAddress, bool reset, uint8_
 
 	initInterface(&mInterface, &bus, slaveAddress, tle493d::resetValues);
 
-	mInterface.bus->begin();
-
 	if(reset == true)
 	{
 		resetSensor();


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

#### **Description**
While trying out a setup with two different TLE493D-p2b6 sensors (A2 and A3) connected to the same IIC bus of an Arduino Teensy 4.0, I encountered malfunctions in communications between the microcontroller and the sensors.
I believe that it is both a logical and a functional mistake to initialize the IIC bus interface (calling `mInterface.bus->begin()`) inside the `void Tle493d::begin(TwoWire &bus, TypeAddress_e slaveAddress, bool reset, uint8_t oneByteRead)
` method as this functionality should not be handled by the sensor instance. Also, this might cause problems with the IIC interface if multiple sensors are connected to the same bus, as a bus (re)initialization can be performed while it is used by another sensor causing malfunction in the interface.

By removing the bus initialization from the library method and performing it only once in the setup of the microcontroller, everything works fine.

Another solution could be to check wether the bus was already initialized with the `isEnabled()` method but, as I wrote, I think this kind of functionality shouldn't be handled by the library.